### PR TITLE
glyphshandler: include line breaks in outputted files

### DIFF
--- a/bumpfontversion/glyphshandler.py
+++ b/bumpfontversion/glyphshandler.py
@@ -29,4 +29,4 @@ class GlyphsHandler:
         font["versionMinor"] = int(new_version["minor"].value)
         logger.info(f"Saving file {file}")
         with open(file, "w", encoding="utf-8") as fp:
-            openstep_plist.dump(font, fp)
+            openstep_plist.dump(font, fp, indent=0)


### PR DESCRIPTION
I'm currently using Glyphsapp v2.6.4 (1286). It crashes when attempting to open glyphs files which have been bumped using this tool.

Currently, when you bump the version, the outputted glyphs file lacks line breaks. I'm fairly sure this is causing my version of Glyphsapp to crash. By setting `indent=0` it will produce glyph files with line breaks. I haven't tested this on other versions so idk if it will work on glyphs 3