### PR TITLE
bump version numbers for designspace ufo sources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,11 @@ license = "Apache"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3"
+python = "^3.7"
 openstep-plist = "*"
 ufoLib2 = "*"
 glyphsLib = "6.0.0b4"
+fontTools = "*"
 bump2version = "1.0.1"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Had to bump python version since fontTools requires 3.7+