### PR TITLE
UFO: Update OpenType Name Table Fields

### DIFF
--- a/bumpfontversion/ufohandler.py
+++ b/bumpfontversion/ufohandler.py
@@ -19,8 +19,28 @@ class UFOHandler:
         )
 
     def set_version(self, file, new_version):
+        def pad_num(num, amount):
+            return str(num).zfill(amount)
+
         font = ufoLib2.objects.Font.open(file)
-        font.info.versionMajor = int(new_version["major"].value)
-        font.info.versionMinor = int(new_version["minor"].value)
+        info = font.info
+
+        current_version = f"{info.versionMajor}.{pad_num(info.versionMinor, 3)}"
+
+        info.versionMajor = int(new_version["major"].value)
+        info.versionMinor = int(new_version["minor"].value)
+
+        new_version = f"{info.versionMajor}.{pad_num(info.versionMinor, 3)}"
+
+        # Set OpenType names
+        for attr in dir(info):
+            if "openTypeName" not in attr or "_" in attr:
+                continue
+            current_string = getattr(info, attr)
+            if not current_string:
+                continue
+            new_string = current_string.replace(current_version, new_version)
+            setattr(info, attr, new_string)
+
         logger.info(f"Saving file {file}")
         font.save(file, overwrite=True)


### PR DESCRIPTION
Currently, the tool will only change the ufo's version major and minor. It doesn't modify the OpenType name records. This PR will modify the name records by inspecting each one and then replacing the previous version number with the new version number.

We discovered this issue whilst working on Open Sans. The name table has version 3.000 while the minor and major have 3.002. https://github.com/google/fonts/pull/6937#issuecomment-1810478290

cc @emmamarichal