### PR TITLE
Do not print the effective log level during normal use.

### DIFF
--- a/bumpfontversion/__main__.py
+++ b/bumpfontversion/__main__.py
@@ -122,8 +122,6 @@ def main():
     if args.verbose:
         logger.setLevel("INFO")
 
-    print(logger.getEffectiveLevel())
-
     if not args.files:
         print("No files to change; nothing to do")
         sys.exit(0)


### PR DESCRIPTION
I noticed the log level was printed during use and without the verbose flag. It looks like a debugging leftover, so I decided to remove it. If intentional, feel free to close this PR.