### PR TITLE
Upgrade glyphsLib

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: daily

--- a/bumpfontversion/ufohandler.py
+++ b/bumpfontversion/ufohandler.py
@@ -19,8 +19,28 @@ class UFOHandler:
         )
 
     def set_version(self, file, new_version):
+        def pad_num(num, amount):
+            return str(num).zfill(amount)
+
         font = ufoLib2.objects.Font.open(file)
-        font.info.versionMajor = int(new_version["major"].value)
-        font.info.versionMinor = int(new_version["minor"].value)
+        info = font.info
+
+        current_version = f"{info.versionMajor}.{pad_num(info.versionMinor, 3)}"
+
+        info.versionMajor = int(new_version["major"].value)
+        info.versionMinor = int(new_version["minor"].value)
+
+        new_version = f"{info.versionMajor}.{pad_num(info.versionMinor, 3)}"
+
+        # Set OpenType names
+        for attr in dir(info):
+            if "openTypeName" not in attr or "_" in attr:
+                continue
+            current_string = getattr(info, attr)
+            if not current_string:
+                continue
+            new_string = current_string.replace(current_version, new_version)
+            setattr(info, attr, new_string)
+
         logger.info(f"Saving file {file}")
         font.save(file, overwrite=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 python = "^3.7"
 openstep-plist = "*"
 ufoLib2 = "*"
-glyphsLib = "6.0.0b4"
+glyphsLib = "^6.6.6"
 fontTools = "*"
 bump2version = "1.0.1"
 


### PR DESCRIPTION
I noticed some recently made Glyphs files became (somewhat) corrupted because glyphsLib didn't support some of the newer features. This updates glyphsLib and sets up dependabot to open a pull request whenever a new glyphsLib version is released (or one of the other dependencies).